### PR TITLE
Remove leaked RAWG API key from tracked gradle.properties

### DIFF
--- a/core-network/build.gradle.kts
+++ b/core-network/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
@@ -5,6 +7,19 @@ plugins {
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.kotlinx.serialization)
 }
+
+val localProperties = Properties().apply {
+    val localPropertiesFile = rootProject.file("local.properties")
+    if (localPropertiesFile.exists()) {
+        localPropertiesFile.inputStream().use { load(it) }
+    }
+}
+
+// Resolution order: local.properties (gitignored, per-developer) > -PAPI_KEY / CI secret > env var > empty.
+val rawgApiKey: String = localProperties.getProperty("API_KEY")
+    ?: providers.gradleProperty("API_KEY").orNull
+    ?: providers.environmentVariable("API_KEY").orNull
+    ?: ""
 
 kotlin {
     jvmToolchain(11)
@@ -62,7 +77,7 @@ android {
 
     defaultConfig {
         minSdk = libs.versions.android.minSdk.get().toInt()
-        buildConfigField("String", "API_KEY", "\"${providers.gradleProperty("API_KEY").get()}\"")
+        buildConfigField("String", "API_KEY", "\"$rawgApiKey\"")
 
     }
     packaging {

--- a/core-network/src/commonMain/kotlin/com/devpush/coreNetwork/client/KtorClient.kt
+++ b/core-network/src/commonMain/kotlin/com/devpush/coreNetwork/client/KtorClient.kt
@@ -20,7 +20,6 @@ object KtorClient {
                 ignoreUnknownKeys = true
             })
         }
-// https://api.rawg.io/api/games?key=1abb1867f52548a4aa9f54dd4946af2f
         install(DefaultRequest) {
             url {
                 host = "api.rawg.io"

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,5 +12,3 @@ android.nonTransitiveRClass=true
 android.useAndroidX=true
 android.builtInKotlin=false
 android.newDsl=false
-
-API_KEY=088a07f75685446a8dd401b51623df34


### PR DESCRIPTION
## Summary
- Found a live RAWG API key committed in plaintext in `gradle.properties`, present since the initial commit and on `main` HEAD.
- Moves key resolution to `local.properties` (gitignored, already the setup CLAUDE.md documents) with fallback to a gradle/env property for CI, so no secret needs to live in tracked files.
- Removes a second key-looking literal that was sitting in a `KtorClient.kt` comment.

**Action needed from repo owner (outside this PR):** rotate the RAWG key — the committed value must be treated as compromised.

## Test plan
- [x] `./gradlew :core-network:compileDebugKotlinAndroid` — BUILD SUCCESSFUL, confirms `local.properties`-based key resolution compiles and wires into `BuildConfig.API_KEY`.
- [x] Confirmed `local.properties` is gitignored and was not staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved API key configuration to support local properties, Gradle or CI settings, and environment variables.
  - Builds no longer require an API key to be explicitly defined in shared project settings.
  - Removed the API key from the shared Gradle configuration to improve credential safety.

- **Chores**
  - Removed an outdated internal API URL comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->